### PR TITLE
Dop 1554 refactor to include dopplermessageservice

### DIFF
--- a/Doppler.Push.Api.Test/DeviceControllerTest.cs
+++ b/Doppler.Push.Api.Test/DeviceControllerTest.cs
@@ -45,7 +45,7 @@ namespace Doppler.Push.Api
 
             Device device = fixture.Create<Device>();
 
-            var firebaseCloudMessageServiceMock = new Mock<IFirebaseCloudMessageService>();
+            var firebaseCloudMessageServiceMock = new Mock<IMessageService>();
 
             firebaseCloudMessageServiceMock
                 .Setup(x => x.GetDevice(It.IsAny<string>()))
@@ -86,7 +86,7 @@ namespace Doppler.Push.Api
 
             Device device = fixture.Create<Device>();
 
-            var firebaseCloudMessageServiceMock = new Mock<IFirebaseCloudMessageService>();
+            var firebaseCloudMessageServiceMock = new Mock<IMessageService>();
 
             firebaseCloudMessageServiceMock
                 .Setup(x => x.GetDevice(It.IsAny<string>()))
@@ -208,7 +208,7 @@ namespace Doppler.Push.Api
             // Arrange
             var fixture = new Fixture();
 
-            var firebaseCloudMessageServiceMock = new Mock<IFirebaseCloudMessageService>();
+            var firebaseCloudMessageServiceMock = new Mock<IMessageService>();
 
             firebaseCloudMessageServiceMock
                 .Setup(x => x.GetDevice(It.IsAny<string>()))
@@ -242,7 +242,7 @@ namespace Doppler.Push.Api
 
             Device device = fixture.Create<Device>();
 
-            var firebaseCloudMessageServiceMock = new Mock<IFirebaseCloudMessageService>();
+            var firebaseCloudMessageServiceMock = new Mock<IMessageService>();
 
             firebaseCloudMessageServiceMock
                 .Setup(x => x.GetDevice(It.IsAny<string>()))
@@ -276,7 +276,7 @@ namespace Doppler.Push.Api
 
             Device device = fixture.Create<Device>();
 
-            var firebaseCloudMessageServiceMock = new Mock<IFirebaseCloudMessageService>();
+            var firebaseCloudMessageServiceMock = new Mock<IMessageService>();
 
             firebaseCloudMessageServiceMock
                 .Setup(x => x.GetDevice(It.IsAny<string>()))

--- a/Doppler.Push.Api.Test/MessageControllerTest.cs
+++ b/Doppler.Push.Api.Test/MessageControllerTest.cs
@@ -25,9 +25,9 @@ namespace Doppler.Push.Api
         {
             _factory = factory;
             _firebaseCloudMessageService.Setup(s => s.SendMulticast(It.IsAny<PushNotificationDTO>()))
-                .ReturnsAsync(new FirebaseMessageSendResponse { SuccessCount = 1, FailureCount = 0, Responses = null });
+                .ReturnsAsync(new MessageSendResponse { SuccessCount = 1, FailureCount = 0, Responses = null });
             _firebaseCloudMessageService.Setup(s => s.SendMulticastAsBatches(It.IsAny<PushNotificationDTO>()))
-                .ReturnsAsync(new FirebaseMessageSendResponse { SuccessCount = 1, FailureCount = 0, Responses = null });
+                .ReturnsAsync(new MessageSendResponse { SuccessCount = 1, FailureCount = 0, Responses = null });
             _client = _factory
                 .WithWebHostBuilder((e) =>
                     e.ConfigureTestServices(services =>

--- a/Doppler.Push.Api.Test/MessageControllerTest.cs
+++ b/Doppler.Push.Api.Test/MessageControllerTest.cs
@@ -17,7 +17,7 @@ namespace Doppler.Push.Api
     public class MessageControllerTest : IClassFixture<WebApplicationFactory<Startup>>
     {
         const string TOKEN_SUPERUSER_VALID = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc1NVIjp0cnVlLCJleHAiOjIwMDAwMDAwMDB9.rUtvRqMxrnQzVHDuAjgWa2GJAJwZ-wpaxqdjwP7gmVa7XJ1pEmvdTMBdirKL5BJIE7j2_hsMvEOKUKVjWUY-IE0e0u7c82TH0l_4zsIztRyHMKtt9QE9rBRQnJf8dcT5PnLiWkV_qEkpiIKQ-wcMZ1m7vQJ0auEPZyyFBKmU2caxkZZOZ8Kw_1dx-7lGUdOsUYad-1Rt-iuETGAFijQrWggcm3kV_KmVe8utznshv2bAdLJWydbsAUEfNof0kZK5Wu9A80DJd3CRiNk8mWjQxF_qPOrGCANOIYofhB13yuYi48_8zVPYku-llDQjF77BmQIIIMrCXs8IMT3Lksdxuw";
-        private readonly Mock<IFirebaseCloudMessageService> _firebaseCloudMessageService = new Mock<IFirebaseCloudMessageService>();
+        private readonly Mock<IMessageService> _firebaseCloudMessageService = new Mock<IMessageService>();
         private readonly WebApplicationFactory<Startup> _factory;
         private readonly HttpClient _client;
 
@@ -32,7 +32,7 @@ namespace Doppler.Push.Api
                 .WithWebHostBuilder((e) =>
                     e.ConfigureTestServices(services =>
                     {
-                        services.AddSingleton<IFirebaseCloudMessageService>(s => _firebaseCloudMessageService.Object);
+                        services.AddSingleton<IMessageService>(s => _firebaseCloudMessageService.Object);
                     }))
                 .CreateClient(new WebApplicationFactoryClientOptions());
         }

--- a/Doppler.Push.Api.Test/MessageControllerTest.cs
+++ b/Doppler.Push.Api.Test/MessageControllerTest.cs
@@ -24,9 +24,9 @@ namespace Doppler.Push.Api
         public MessageControllerTest(WebApplicationFactory<Startup> factory)
         {
             _factory = factory;
-            _firebaseCloudMessageService.Setup(s => s.SendMulticast(It.IsAny<FirebaseMessageSendRequest>()))
+            _firebaseCloudMessageService.Setup(s => s.SendMulticast(It.IsAny<PushNotificationDTO>()))
                 .ReturnsAsync(new FirebaseMessageSendResponse { SuccessCount = 1, FailureCount = 0, Responses = null });
-            _firebaseCloudMessageService.Setup(s => s.SendMulticastAsBatches(It.IsAny<FirebaseMessageSendRequest>()))
+            _firebaseCloudMessageService.Setup(s => s.SendMulticastAsBatches(It.IsAny<PushNotificationDTO>()))
                 .ReturnsAsync(new FirebaseMessageSendResponse { SuccessCount = 1, FailureCount = 0, Responses = null });
             _client = _factory
                 .WithWebHostBuilder((e) =>

--- a/Doppler.Push.Api/Contract/ExceptionItem.cs
+++ b/Doppler.Push.Api/Contract/ExceptionItem.cs
@@ -1,7 +1,8 @@
 namespace Doppler.Push.Api.Contract
 {
-    public class FirebaseExceptionItem
+    public class ExceptionItem
     {
+        // Error codes information related to FCM (Firebase Cloud Messaging)
         // Summary:
         //     APNs certificate or web push auth key was invalid or missing.
         //ThirdPartyAuthError = 0,
@@ -23,6 +24,7 @@ namespace Doppler.Push.Api.Contract
         //
         //     App instance was unregistered from FCM. This usually means that the token used is no longer valid and a new one must be used.
         //Unregistered = 6
+
         public int MessagingErrorCode { get; set; }
         public string Message { get; set; }
     }

--- a/Doppler.Push.Api/Contract/FirebaseMessageSendRequest.cs
+++ b/Doppler.Push.Api/Contract/FirebaseMessageSendRequest.cs
@@ -1,13 +1,7 @@
-using System.Collections.Generic;
-
 namespace Doppler.Push.Api.Contract
 {
-    public class FirebaseMessageSendRequest
+    public class FirebaseMessageSendRequest : MessageSendRequest
     {
         public string[] Tokens { get; set; }
-        public string NotificationTitle { get; set; }
-        public string NotificationBody { get; set; }
-        public string NotificationOnClickLink { get; set; }
-        public string ImageUrl { get; set; }
     }
 }

--- a/Doppler.Push.Api/Contract/MessageSendRequest.cs
+++ b/Doppler.Push.Api/Contract/MessageSendRequest.cs
@@ -1,0 +1,10 @@
+namespace Doppler.Push.Api.Contract
+{
+    public class MessageSendRequest
+    {
+        public string NotificationTitle { get; set; }
+        public string NotificationBody { get; set; }
+        public string NotificationOnClickLink { get; set; }
+        public string ImageUrl { get; set; }
+    }
+}

--- a/Doppler.Push.Api/Contract/MessageSendResponse.cs
+++ b/Doppler.Push.Api/Contract/MessageSendResponse.cs
@@ -2,9 +2,9 @@ using System.Collections.Generic;
 
 namespace Doppler.Push.Api.Contract
 {
-    public class FirebaseMessageSendResponse
+    public class MessageSendResponse
     {
-        public IEnumerable<FirebaseResponseItem> Responses { get; set; }
+        public IEnumerable<ResponseItem> Responses { get; set; }
         public int SuccessCount { get; set; }
         public int FailureCount { get; set; }
     }

--- a/Doppler.Push.Api/Contract/PushNotificationDTO.cs
+++ b/Doppler.Push.Api/Contract/PushNotificationDTO.cs
@@ -1,0 +1,20 @@
+namespace Doppler.Push.Api.Contract
+{
+    public class PushNotificationDTO
+    {
+        public string NotificationTitle { get; set; }
+        public string NotificationBody { get; set; }
+        public string NotificationOnClickLink { get; set; }
+        public string ImageUrl { get; set; }
+
+        public string[] Tokens { get; set; }
+        public SubscriptionDTO[] Subscriptions { get; set; }
+    }
+
+    public class SubscriptionDTO
+    {
+        public string Endpoint { get; set; }
+        public string P256DH { get; set; }
+        public string Auth { get; set; }
+    }
+}

--- a/Doppler.Push.Api/Contract/PushNotificationRequest.cs
+++ b/Doppler.Push.Api/Contract/PushNotificationRequest.cs
@@ -1,0 +1,14 @@
+namespace Doppler.Push.Api.Contract
+{
+    public class PushNotificationRequest : MessageSendRequest
+    {
+        public Subscription[] Subscriptions { get; set; }
+    }
+
+    public class Subscription
+    {
+        public string Endpoint { get; set; }
+        public string P256DH { get; set; }
+        public string Auth { get; set; }
+    }
+}

--- a/Doppler.Push.Api/Contract/ResponseItem.cs
+++ b/Doppler.Push.Api/Contract/ResponseItem.cs
@@ -1,10 +1,10 @@
 namespace Doppler.Push.Api.Contract
 {
-    public class FirebaseResponseItem
+    public class ResponseItem
     {
         public string MessageId { get; set; }
         public bool IsSuccess { get; set; }
-        public FirebaseExceptionItem Exception { get; set; }
+        public ExceptionItem Exception { get; set; }
         public string DeviceToken { get; set; }
     }
 }

--- a/Doppler.Push.Api/Controllers/DeviceController.cs
+++ b/Doppler.Push.Api/Controllers/DeviceController.cs
@@ -12,9 +12,9 @@ namespace Doppler.Push.Api.Controllers
     [ApiController]
     public class DeviceController
     {
-        private readonly IFirebaseCloudMessageService _firebaseCloudMessageService;
+        private readonly IMessageService _firebaseCloudMessageService;
 
-        public DeviceController(IFirebaseCloudMessageService firebaseCloudMessageService)
+        public DeviceController(IMessageService firebaseCloudMessageService)
         {
             _firebaseCloudMessageService = firebaseCloudMessageService;
         }

--- a/Doppler.Push.Api/Controllers/MessageController.cs
+++ b/Doppler.Push.Api/Controllers/MessageController.cs
@@ -22,7 +22,15 @@ namespace Doppler.Push.Api.Controllers
         [HttpPost]
         public async Task<IActionResult> MessageSend(FirebaseMessageSendRequest messageSend)
         {
-            var response = await _firebaseCloudMessageService.SendMulticastAsBatches(messageSend);
+            var dto = new PushNotificationDTO()
+            {
+                NotificationTitle = messageSend.NotificationTitle,
+                NotificationBody = messageSend.NotificationBody,
+                NotificationOnClickLink = messageSend.NotificationOnClickLink,
+                ImageUrl = messageSend.ImageUrl,
+                Tokens = messageSend.Tokens,
+            };
+            var response = await _firebaseCloudMessageService.SendMulticastAsBatches(dto);
 
             return Ok(response);
         }

--- a/Doppler.Push.Api/Controllers/MessageController.cs
+++ b/Doppler.Push.Api/Controllers/MessageController.cs
@@ -12,9 +12,9 @@ namespace Doppler.Push.Api.Controllers
     [Route("[controller]")]
     public class MessageController : ControllerBase
     {
-        private IFirebaseCloudMessageService _firebaseCloudMessageService;
+        private IMessageService _firebaseCloudMessageService;
 
-        public MessageController(IFirebaseCloudMessageService firebaseCloudMessageService)
+        public MessageController(IMessageService firebaseCloudMessageService)
         {
             _firebaseCloudMessageService = firebaseCloudMessageService;
         }

--- a/Doppler.Push.Api/Controllers/MessageController.cs
+++ b/Doppler.Push.Api/Controllers/MessageController.cs
@@ -3,6 +3,9 @@ using Doppler.Push.Api.DopplerSecurity;
 using Doppler.Push.Api.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Doppler.Push.Api.Controllers
@@ -13,10 +16,12 @@ namespace Doppler.Push.Api.Controllers
     public class MessageController : ControllerBase
     {
         private IMessageService _firebaseCloudMessageService;
+        private IMessageService _dopplerMessageService;
 
-        public MessageController(IMessageService firebaseCloudMessageService)
+        public MessageController(IServiceProvider serviceProvider)
         {
-            _firebaseCloudMessageService = firebaseCloudMessageService;
+            _firebaseCloudMessageService = serviceProvider.GetRequiredService<FirebaseCloudMessageService>();
+            _dopplerMessageService = serviceProvider.GetRequiredService<DopplerMessageService>();
         }
 
         [HttpPost]
@@ -33,6 +38,40 @@ namespace Doppler.Push.Api.Controllers
             var response = await _firebaseCloudMessageService.SendMulticastAsBatches(dto);
 
             return Ok(response);
+        }
+
+        [HttpPost]
+        [Route("/webpush")]
+        public async Task<IActionResult> SendWebPush(PushNotificationRequest pushNotificationRequest)
+        {
+            // TODO: reply 400 when "Suscriptions" field is missing
+            var dto = new PushNotificationDTO()
+            {
+                NotificationTitle = pushNotificationRequest.NotificationTitle,
+                NotificationBody = pushNotificationRequest.NotificationBody,
+                NotificationOnClickLink = pushNotificationRequest.NotificationOnClickLink,
+                ImageUrl = pushNotificationRequest.ImageUrl,
+                Subscriptions = MapSubscriptions(pushNotificationRequest.Subscriptions),
+            };
+
+            var response = await _dopplerMessageService.SendMulticastAsBatches(dto);
+
+            return Ok(response);
+        }
+
+        private SubscriptionDTO[] MapSubscriptions(Subscription[] subscriptions)
+        {
+            if (subscriptions == null)
+            {
+                return null;
+            }
+
+            return subscriptions.Select(sub => new SubscriptionDTO
+            {
+                Endpoint = sub.Endpoint,
+                P256DH = sub.P256DH,
+                Auth = sub.Auth
+            }).ToArray();
         }
     }
 }

--- a/Doppler.Push.Api/Controllers/MessageController.cs
+++ b/Doppler.Push.Api/Controllers/MessageController.cs
@@ -18,10 +18,10 @@ namespace Doppler.Push.Api.Controllers
         private IMessageService _firebaseCloudMessageService;
         private IMessageService _dopplerMessageService;
 
-        public MessageController(IServiceProvider serviceProvider)
+        public MessageController(IMessageServiceFactory messageServiceFactory)
         {
-            _firebaseCloudMessageService = serviceProvider.GetRequiredService<FirebaseCloudMessageService>();
-            _dopplerMessageService = serviceProvider.GetRequiredService<DopplerMessageService>();
+            _firebaseCloudMessageService = messageServiceFactory.CreateFirebaseCloudMessageService();
+            _dopplerMessageService = messageServiceFactory.CreateDopplerMessageService();
         }
 
         [HttpPost]

--- a/Doppler.Push.Api/Services/DopplerMessageService.cs
+++ b/Doppler.Push.Api/Services/DopplerMessageService.cs
@@ -1,0 +1,31 @@
+using Doppler.Push.Api.Contract;
+using System;
+using System.Threading.Tasks;
+
+namespace Doppler.Push.Api.Services
+{
+    public class DopplerMessageService : IMessageService
+    {
+        public DopplerMessageService()
+        {
+        }
+
+        public async Task<MessageSendResponse> SendMulticast(PushNotificationDTO request)
+        {
+            await Task.Yield(); // it allows us to consider an async method without doing an operation
+            throw new Exception("Not implemented");
+        }
+
+        public async Task<MessageSendResponse> SendMulticastAsBatches(PushNotificationDTO request)
+        {
+            await Task.Yield(); // it allows us to consider an async method without doing an operation
+            throw new Exception("Not implemented");
+        }
+
+        public async Task<Device> GetDevice(string token)
+        {
+            await Task.Yield(); // it allows us to consider an async method without doing an operation
+            throw new Exception("Not implemented");
+        }
+    }
+}

--- a/Doppler.Push.Api/Services/FirebaseCloudMessageService.cs
+++ b/Doppler.Push.Api/Services/FirebaseCloudMessageService.cs
@@ -30,7 +30,7 @@ namespace Doppler.Push.Api.Services
             _firebaseCloudMessageServiceSettings = firebaseCloudMessageServiceSettings.Value;
         }
 
-        public async Task<FirebaseMessageSendResponse> SendMulticast(PushNotificationDTO request)
+        public async Task<MessageSendResponse> SendMulticast(PushNotificationDTO request)
         {
             var message = new MulticastMessage()
             {
@@ -53,14 +53,14 @@ namespace Doppler.Push.Api.Services
 
             var response = await _firebaseService.SendMulticastAsync(message);
 
-            var returnResponse = new FirebaseMessageSendResponse()
+            var returnResponse = new MessageSendResponse()
             {
-                Responses = response.Responses.Select((x, index) => new FirebaseResponseItem
+                Responses = response.Responses.Select((x, index) => new ResponseItem
                 {
                     IsSuccess = x.IsSuccess,
                     MessageId = x.MessageId,
                     DeviceToken = request.Tokens[index],
-                    Exception = x.IsSuccess ? null : new FirebaseExceptionItem
+                    Exception = x.IsSuccess ? null : new ExceptionItem
                     {
                         Message = x.Exception.Message,
                         MessagingErrorCode = x.Exception.MessagingErrorCode.HasValue ? (int)x.Exception.MessagingErrorCode : 0
@@ -73,7 +73,7 @@ namespace Doppler.Push.Api.Services
             return returnResponse;
         }
 
-        public async Task<FirebaseMessageSendResponse> SendMulticastAsBatches(PushNotificationDTO request)
+        public async Task<MessageSendResponse> SendMulticastAsBatches(PushNotificationDTO request)
         {
             var requestsBatches = request.Tokens
                 .Batch(_firebaseCloudMessageServiceSettings.BatchesSize) // TODO: replace with Enumerable.Chunk after NET 6 migration https://docs.microsoft.com/en-us/dotnet/api/system.linq.enumerable.chunk?view=net-6.0
@@ -88,7 +88,7 @@ namespace Doppler.Push.Api.Services
                     });
 
             // TODO: refactor to use a declarative implementation instead of mutable variables
-            var allResponses = new List<FirebaseResponseItem>();
+            var allResponses = new List<ResponseItem>();
             var allFailureCount = 0;
             var allSuccessCount = 0;
 
@@ -101,7 +101,7 @@ namespace Doppler.Push.Api.Services
                 allSuccessCount += response.SuccessCount;
             }
 
-            return new FirebaseMessageSendResponse
+            return new MessageSendResponse
             {
                 Responses = allResponses,
                 FailureCount = allFailureCount,

--- a/Doppler.Push.Api/Services/FirebaseCloudMessageService.cs
+++ b/Doppler.Push.Api/Services/FirebaseCloudMessageService.cs
@@ -13,7 +13,7 @@ using System.Threading.Tasks;
 
 namespace Doppler.Push.Api.Services
 {
-    public class FirebaseCloudMessageService : IFirebaseCloudMessageService
+    public class FirebaseCloudMessageService : IMessageService
     {
         private readonly FirebaseMessaging _firebaseService;
         private readonly FirebaseCloudMessageServiceSettings _firebaseCloudMessageServiceSettings;

--- a/Doppler.Push.Api/Services/FirebaseCloudMessageService.cs
+++ b/Doppler.Push.Api/Services/FirebaseCloudMessageService.cs
@@ -30,7 +30,7 @@ namespace Doppler.Push.Api.Services
             _firebaseCloudMessageServiceSettings = firebaseCloudMessageServiceSettings.Value;
         }
 
-        public async Task<FirebaseMessageSendResponse> SendMulticast(FirebaseMessageSendRequest request)
+        public async Task<FirebaseMessageSendResponse> SendMulticast(PushNotificationDTO request)
         {
             var message = new MulticastMessage()
             {
@@ -73,12 +73,12 @@ namespace Doppler.Push.Api.Services
             return returnResponse;
         }
 
-        public async Task<FirebaseMessageSendResponse> SendMulticastAsBatches(FirebaseMessageSendRequest request)
+        public async Task<FirebaseMessageSendResponse> SendMulticastAsBatches(PushNotificationDTO request)
         {
             var requestsBatches = request.Tokens
                 .Batch(_firebaseCloudMessageServiceSettings.BatchesSize) // TODO: replace with Enumerable.Chunk after NET 6 migration https://docs.microsoft.com/en-us/dotnet/api/system.linq.enumerable.chunk?view=net-6.0
                 .Select(x =>
-                    new FirebaseMessageSendRequest
+                    new PushNotificationDTO
                     {
                         Tokens = x as string[],
                         NotificationTitle = request.NotificationTitle,

--- a/Doppler.Push.Api/Services/IFirebaseCloudMessageService.cs
+++ b/Doppler.Push.Api/Services/IFirebaseCloudMessageService.cs
@@ -5,9 +5,9 @@ namespace Doppler.Push.Api.Services
 {
     public interface IFirebaseCloudMessageService
     {
-        Task<FirebaseMessageSendResponse> SendMulticast(PushNotificationDTO request);
+        Task<MessageSendResponse> SendMulticast(PushNotificationDTO request);
 
-        Task<FirebaseMessageSendResponse> SendMulticastAsBatches(PushNotificationDTO request);
+        Task<MessageSendResponse> SendMulticastAsBatches(PushNotificationDTO request);
 
         Task<Device> GetDevice(string token);
     }

--- a/Doppler.Push.Api/Services/IFirebaseCloudMessageService.cs
+++ b/Doppler.Push.Api/Services/IFirebaseCloudMessageService.cs
@@ -5,9 +5,9 @@ namespace Doppler.Push.Api.Services
 {
     public interface IFirebaseCloudMessageService
     {
-        Task<FirebaseMessageSendResponse> SendMulticast(FirebaseMessageSendRequest request);
+        Task<FirebaseMessageSendResponse> SendMulticast(PushNotificationDTO request);
 
-        Task<FirebaseMessageSendResponse> SendMulticastAsBatches(FirebaseMessageSendRequest request);
+        Task<FirebaseMessageSendResponse> SendMulticastAsBatches(PushNotificationDTO request);
 
         Task<Device> GetDevice(string token);
     }

--- a/Doppler.Push.Api/Services/IMessageService.cs
+++ b/Doppler.Push.Api/Services/IMessageService.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 
 namespace Doppler.Push.Api.Services
 {
-    public interface IFirebaseCloudMessageService
+    public interface IMessageService
     {
         Task<MessageSendResponse> SendMulticast(PushNotificationDTO request);
 

--- a/Doppler.Push.Api/Services/IMessageServiceFactory.cs
+++ b/Doppler.Push.Api/Services/IMessageServiceFactory.cs
@@ -1,0 +1,8 @@
+namespace Doppler.Push.Api.Services
+{
+    public interface IMessageServiceFactory
+    {
+        IMessageService CreateFirebaseCloudMessageService();
+        IMessageService CreateDopplerMessageService();
+    }
+}

--- a/Doppler.Push.Api/Services/MessageServiceFactory.cs
+++ b/Doppler.Push.Api/Services/MessageServiceFactory.cs
@@ -1,0 +1,25 @@
+using Microsoft.Extensions.DependencyInjection;
+using System;
+
+namespace Doppler.Push.Api.Services
+{
+    public class MessageServiceFactory : IMessageServiceFactory
+    {
+        private readonly IServiceProvider _serviceProvider;
+
+        public MessageServiceFactory(IServiceProvider serviceProvider)
+        {
+            _serviceProvider = serviceProvider;
+        }
+
+        public IMessageService CreateFirebaseCloudMessageService()
+        {
+            return _serviceProvider.GetRequiredService<FirebaseCloudMessageService>();
+        }
+
+        public IMessageService CreateDopplerMessageService()
+        {
+            return _serviceProvider.GetRequiredService<DopplerMessageService>();
+        }
+    }
+}

--- a/Doppler.Push.Api/Startup.cs
+++ b/Doppler.Push.Api/Startup.cs
@@ -57,7 +57,7 @@ namespace Doppler.Push.Api
                 };
             });
 
-            services.AddSingleton<IFirebaseCloudMessageService, FirebaseCloudMessageService>();
+            services.AddSingleton<IMessageService, FirebaseCloudMessageService>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/Doppler.Push.Api/Startup.cs
+++ b/Doppler.Push.Api/Startup.cs
@@ -1,4 +1,5 @@
 using Doppler.Push.Api.DopplerSecurity;
+using Doppler.Push.Api.Services;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
@@ -6,7 +7,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.OpenApi.Models;
 using System;
-using Doppler.Push.Api.Services;
 
 namespace Doppler.Push.Api
 {
@@ -57,7 +57,8 @@ namespace Doppler.Push.Api
                 };
             });
 
-            services.AddSingleton<IMessageService, FirebaseCloudMessageService>();
+            services.AddSingleton<FirebaseCloudMessageService>();
+            services.AddSingleton<DopplerMessageService>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/Doppler.Push.Api/Startup.cs
+++ b/Doppler.Push.Api/Startup.cs
@@ -59,6 +59,7 @@ namespace Doppler.Push.Api
 
             services.AddSingleton<FirebaseCloudMessageService>();
             services.AddSingleton<DopplerMessageService>();
+            services.AddSingleton<IMessageServiceFactory, MessageServiceFactory>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.


### PR DESCRIPTION
Rename the interface `IFirebaseCloudMessageService` by `IMessageService`, and some dto/model objects, to extract behavior to be implemented by `FirebaseCloudMessageService` (the current implementation) and `DopplerMessageService` (the new one implementation).

Also, add a new endpoint `/webpush` which will implement sending notifications with the Doppler Service.

Note: review commit by commit to understanding better.