### PR TITLE
Dop 1554 sending using dopplermessageservice

### DIFF
--- a/Doppler.Push.Api.Test/MessageControllerTest.cs
+++ b/Doppler.Push.Api.Test/MessageControllerTest.cs
@@ -1,3 +1,4 @@
+using AutoFixture;
 using Doppler.Push.Api.Contract;
 using Doppler.Push.Api.Services;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -5,6 +6,7 @@ using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Newtonsoft.Json;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -18,6 +20,7 @@ namespace Doppler.Push.Api
     {
         const string TOKEN_SUPERUSER_VALID = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc1NVIjp0cnVlLCJleHAiOjIwMDAwMDAwMDB9.rUtvRqMxrnQzVHDuAjgWa2GJAJwZ-wpaxqdjwP7gmVa7XJ1pEmvdTMBdirKL5BJIE7j2_hsMvEOKUKVjWUY-IE0e0u7c82TH0l_4zsIztRyHMKtt9QE9rBRQnJf8dcT5PnLiWkV_qEkpiIKQ-wcMZ1m7vQJ0auEPZyyFBKmU2caxkZZOZ8Kw_1dx-7lGUdOsUYad-1Rt-iuETGAFijQrWggcm3kV_KmVe8utznshv2bAdLJWydbsAUEfNof0kZK5Wu9A80DJd3CRiNk8mWjQxF_qPOrGCANOIYofhB13yuYi48_8zVPYku-llDQjF77BmQIIIMrCXs8IMT3Lksdxuw";
         private readonly Mock<IMessageService> _firebaseCloudMessageService = new Mock<IMessageService>();
+        private readonly Mock<IMessageService> _dopplerMessageService = new Mock<IMessageService>();
         private readonly WebApplicationFactory<Startup> _factory;
         private readonly HttpClient _client;
 
@@ -30,8 +33,12 @@ namespace Doppler.Push.Api
             _firebaseCloudMessageService.Setup(s => s.SendMulticastAsBatches(It.IsAny<PushNotificationDTO>()))
                 .ReturnsAsync(new MessageSendResponse { SuccessCount = 1, FailureCount = 0, Responses = null });
 
+            _dopplerMessageService.Setup(s => s.SendMulticast(It.IsAny<PushNotificationDTO>()))
+                .ReturnsAsync(new MessageSendResponse { SuccessCount = 1, FailureCount = 0, Responses = null });
+
             var messageServiceFactoryMock = new Mock<IMessageServiceFactory>();
             messageServiceFactoryMock.Setup(f => f.CreateFirebaseCloudMessageService()).Returns(_firebaseCloudMessageService.Object);
+            messageServiceFactoryMock.Setup(f => f.CreateDopplerMessageService()).Returns(_dopplerMessageService.Object);
 
             _client = _factory
                 .WithWebHostBuilder((e) =>
@@ -39,12 +46,13 @@ namespace Doppler.Push.Api
                     {
                         services.AddSingleton<IMessageServiceFactory>(_ => messageServiceFactoryMock.Object);
                         services.AddSingleton<IMessageService>(s => _firebaseCloudMessageService.Object);
+                        services.AddSingleton<IMessageService>(s => _dopplerMessageService.Object);
                     }))
                 .CreateClient(new WebApplicationFactoryClientOptions());
         }
 
         [Fact]
-        public async Task POST_messageSend_return_correct_status_when_contract_valid()
+        public async Task POST_messageSend_return_OK_when_contract_valid()
         {
             // Arrange
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", TOKEN_SUPERUSER_VALID);
@@ -56,6 +64,60 @@ namespace Doppler.Push.Api
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task POST_SendWebPush_return_OK_when_contract_valid()
+        {
+            // Arrange
+            _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", TOKEN_SUPERUSER_VALID);
+
+            var fixture = new Fixture();
+            var subscription = fixture.Create<Subscription>();
+
+            var pushNotificationRequest = new
+            {
+                NotificationTitle = "title",
+                NotificationBody = "body",
+                Subscriptions = new[] { subscription }
+            };
+
+            var stringContent = new StringContent(JsonConvert.SerializeObject(pushNotificationRequest), Encoding.UTF8, "application/json");
+
+            // Act
+            var response = await _client.PostAsync("/webpush", stringContent);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        public static IEnumerable<object[]> NullOrEmptySubscriptionsData()
+        {
+            yield return new object[] { null };
+            yield return new object[] { new Subscription[] { } };
+        }
+
+        [Theory]
+        [MemberData(nameof(NullOrEmptySubscriptionsData))]
+        public async Task POST_SendWebPush_return_BadRequest_when_subscriptions_are_null_or_empty(Subscription[] subscriptions)
+        {
+            // Arrange
+            _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", TOKEN_SUPERUSER_VALID);
+
+            var pushNotificationRequest = new
+            {
+                NotificationTitle = "title",
+                NotificationBody = "body",
+                Subscriptions = subscriptions
+            };
+
+            var stringContent = new StringContent(JsonConvert.SerializeObject(pushNotificationRequest), Encoding.UTF8, "application/json");
+
+            // Act
+            var response = await _client.PostAsync("/webpush", stringContent);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
         }
     }
 }

--- a/Doppler.Push.Api.Test/Services/DopplerMessageServiceTest.cs
+++ b/Doppler.Push.Api.Test/Services/DopplerMessageServiceTest.cs
@@ -1,0 +1,172 @@
+using AutoFixture;
+using Doppler.Push.Api.Contract;
+using Microsoft.Extensions.Options;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Doppler.Push.Api.Services
+{
+    public class DopplerMessageServiceTest
+    {
+        private static DopplerMessageService CreateSut(IOptions<WebPushSettings> webPushSettings = null, IWebPushClient webPushClient = null)
+        {
+            return new DopplerMessageService(
+                webPushSettings ?? Mock.Of<IOptions<WebPushSettings>>(),
+                webPushClient ?? Mock.Of<IWebPushClient>()
+            );
+        }
+
+        public static IEnumerable<object[]> SubscriptionsData()
+        {
+            var fixture = new Fixture();
+            var s1 = fixture.Create<SubscriptionDTO>();
+            var r1 = new ResponseItem()
+            {
+                Subscription = s1,
+                IsSuccess = true,
+                Exception = null
+            };
+
+            var s2 = fixture.Create<SubscriptionDTO>();
+            var r2 = new ResponseItem()
+            {
+                Subscription = s2,
+                IsSuccess = false,
+                Exception = new ExceptionItem() { Message = "Error in s2" },
+            };
+
+            yield return new object[] { s1, r1, true };
+            yield return new object[] { s2, r2, false };
+        }
+
+        [Theory]
+        [MemberData(nameof(SubscriptionsData))]
+        public async Task SendMulticast_should_return_a_reponse_with_correct_success_and_failure_quantity(
+            SubscriptionDTO subscription,
+            ResponseItem responseItem,
+            bool subscriptionProcessedOk
+        )
+        {
+            // Arrange
+            var fixture = new Fixture();
+
+            var pushNotification = fixture.Create<PushNotificationDTO>();
+            pushNotification.Subscriptions = new SubscriptionDTO[] { subscription };
+
+            var webPushSettingsMock = fixture.Create<WebPushSettings>();
+
+            var webPushClientMock = new Mock<IWebPushClient>();
+            webPushClientMock
+                .Setup(x => x.SetVapidDetails(webPushSettingsMock.Subject, webPushSettingsMock.PublicKey, webPushSettingsMock.PrivateKey));
+            webPushClientMock
+                .Setup(x => x.SendNotificationAsync(subscription, It.IsAny<string>(), default, default))
+                .ReturnsAsync(responseItem);
+
+            var sut = CreateSut(Options.Create(webPushSettingsMock), webPushClientMock.Object);
+
+            // Act
+            var response = await sut.SendMulticast(pushNotification);
+
+            // Assert
+            Assert.NotNull(response);
+            Assert.True(response.SuccessCount == (subscriptionProcessedOk ? 1 : 0));
+            Assert.True(response.FailureCount == (subscriptionProcessedOk ? 0 : 1));
+
+            var firstResponseFromResponses = response.Responses.First();
+            if (subscriptionProcessedOk)
+            {
+                Assert.Null(firstResponseFromResponses.Exception);
+            }
+            else
+            {
+                Assert.NotNull(firstResponseFromResponses.Exception);
+            }
+        }
+
+        [Fact]
+        public async Task SendMulticast_should_return_a_reponse_with_BadRequest_statuscode()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var subscription = fixture.Create<SubscriptionDTO>();
+
+            var expectedExceptionMessage = "An Argument Exception";
+
+            var pushNotification = fixture.Create<PushNotificationDTO>();
+            pushNotification.Subscriptions = new SubscriptionDTO[] { subscription };
+
+            var webPushSettingsMock = fixture.Create<WebPushSettings>();
+
+            var webPushClientMock = new Mock<IWebPushClient>();
+            webPushClientMock
+                .Setup(x => x.SetVapidDetails(webPushSettingsMock.Subject, webPushSettingsMock.PublicKey, webPushSettingsMock.PrivateKey));
+            webPushClientMock
+                .Setup(x => x.SendNotificationAsync(subscription, It.IsAny<string>(), default, default))
+                .ThrowsAsync(new ArgumentException(expectedExceptionMessage));
+
+            var sut = CreateSut(Options.Create(webPushSettingsMock), webPushClientMock.Object);
+
+            // Act
+            var response = await sut.SendMulticast(pushNotification);
+
+            // Assert
+            Assert.NotNull(response);
+            Assert.True(response.SuccessCount == 0);
+            Assert.True(response.FailureCount == 1);
+
+            var firstSubscriptionResponse = response.Responses.First();
+            Assert.NotNull(firstSubscriptionResponse);
+            Assert.Equal(subscription, firstSubscriptionResponse.Subscription);
+
+            var responseSubscriptionException = firstSubscriptionResponse.Exception;
+            Assert.NotNull(responseSubscriptionException);
+            Assert.Equal(expectedExceptionMessage, responseSubscriptionException.Message);
+            Assert.Equal((int)HttpStatusCode.BadRequest, responseSubscriptionException.MessagingErrorCode);
+        }
+
+        [Fact]
+        public async Task SendMulticast_should_return_a_reponse_with_InternalServerError__statuscode()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var subscription = fixture.Create<SubscriptionDTO>();
+
+            var expectedExceptionMessage = "An Argument Exception";
+
+            var pushNotification = fixture.Create<PushNotificationDTO>();
+            pushNotification.Subscriptions = new SubscriptionDTO[] { subscription };
+
+            var webPushSettingsMock = fixture.Create<WebPushSettings>();
+
+            var webPushClientMock = new Mock<IWebPushClient>();
+            webPushClientMock
+                .Setup(x => x.SetVapidDetails(webPushSettingsMock.Subject, webPushSettingsMock.PublicKey, webPushSettingsMock.PrivateKey));
+            webPushClientMock
+                .Setup(x => x.SendNotificationAsync(subscription, It.IsAny<string>(), default, default))
+                .ThrowsAsync(new Exception(expectedExceptionMessage));
+
+            var sut = CreateSut(Options.Create(webPushSettingsMock), webPushClientMock.Object);
+
+            // Act
+            var response = await sut.SendMulticast(pushNotification);
+
+            // Assert
+            Assert.NotNull(response);
+            Assert.True(response.SuccessCount == 0);
+            Assert.True(response.FailureCount == 1);
+
+            var firstSubscriptionResponse = response.Responses.First();
+            Assert.NotNull(firstSubscriptionResponse);
+            Assert.Equal(subscription, firstSubscriptionResponse.Subscription);
+
+            var responseSubscriptionException = firstSubscriptionResponse.Exception;
+            Assert.NotNull(responseSubscriptionException);
+            Assert.Equal((int)HttpStatusCode.InternalServerError, responseSubscriptionException.MessagingErrorCode);
+        }
+    }
+}

--- a/Doppler.Push.Api/Contract/MessageSendRequest.cs
+++ b/Doppler.Push.Api/Contract/MessageSendRequest.cs
@@ -6,5 +6,6 @@ namespace Doppler.Push.Api.Contract
         public string NotificationBody { get; set; }
         public string NotificationOnClickLink { get; set; }
         public string ImageUrl { get; set; }
+        public string IconUrl { get; set; }
     }
 }

--- a/Doppler.Push.Api/Contract/NotificationPayload.cs
+++ b/Doppler.Push.Api/Contract/NotificationPayload.cs
@@ -7,8 +7,12 @@ namespace Doppler.Push.Api.Contract
         // TODO: analyze: this identifier could be used to count deliveries and clicks
         [JsonProperty("messageId")]
         public string MessageId { get; set; }
+
+        [JsonProperty("clickLink")]
+        public string ClickLink { get; set; }
     }
 
+    // Note: all of these values are considered on 'showNotification' in the service worker
     public class NotificationPayload
     {
         [JsonProperty("title")]
@@ -19,6 +23,9 @@ namespace Doppler.Push.Api.Contract
 
         [JsonProperty("icon")]
         public string Icon { get; set; }
+
+        [JsonProperty("image")]
+        public string Image { get; set; }
 
         [JsonProperty("data")]
         public NotificationData Data { get; set; }

--- a/Doppler.Push.Api/Contract/NotificationPayload.cs
+++ b/Doppler.Push.Api/Contract/NotificationPayload.cs
@@ -4,6 +4,7 @@ namespace Doppler.Push.Api.Contract
 {
     public class NotificationData
     {
+        // TODO: analyze: this identifier could be used to count deliveries and clicks
         [JsonProperty("messageId")]
         public string MessageId { get; set; }
     }

--- a/Doppler.Push.Api/Contract/NotificationPayload.cs
+++ b/Doppler.Push.Api/Contract/NotificationPayload.cs
@@ -1,0 +1,25 @@
+using Newtonsoft.Json;
+
+namespace Doppler.Push.Api.Contract
+{
+    public class NotificationData
+    {
+        [JsonProperty("messageId")]
+        public string MessageId { get; set; }
+    }
+
+    public class NotificationPayload
+    {
+        [JsonProperty("title")]
+        public string Title { get; set; }
+
+        [JsonProperty("body")]
+        public string Body { get; set; }
+
+        [JsonProperty("icon")]
+        public string Icon { get; set; }
+
+        [JsonProperty("data")]
+        public NotificationData Data { get; set; }
+    }
+}

--- a/Doppler.Push.Api/Contract/PushNotificationDTO.cs
+++ b/Doppler.Push.Api/Contract/PushNotificationDTO.cs
@@ -6,6 +6,7 @@ namespace Doppler.Push.Api.Contract
         public string NotificationBody { get; set; }
         public string NotificationOnClickLink { get; set; }
         public string ImageUrl { get; set; }
+        public string IconUrl { get; set; }
 
         public string[] Tokens { get; set; }
         public SubscriptionDTO[] Subscriptions { get; set; }

--- a/Doppler.Push.Api/Contract/PushNotificationDTO.cs
+++ b/Doppler.Push.Api/Contract/PushNotificationDTO.cs
@@ -9,6 +9,9 @@ namespace Doppler.Push.Api.Contract
 
         public string[] Tokens { get; set; }
         public SubscriptionDTO[] Subscriptions { get; set; }
+
+        // TODO: analyze: this identifier could be used to count deliveries and clicks
+        public string MessageId { get; set; }
     }
 
     public class SubscriptionDTO

--- a/Doppler.Push.Api/Contract/PushNotificationRequest.cs
+++ b/Doppler.Push.Api/Contract/PushNotificationRequest.cs
@@ -3,6 +3,8 @@ namespace Doppler.Push.Api.Contract
     public class PushNotificationRequest : MessageSendRequest
     {
         public Subscription[] Subscriptions { get; set; }
+        // TODO: analyze: this identifier could be used to count deliveries and clicks
+        public string MessageId { get; set; }
     }
 
     public class Subscription

--- a/Doppler.Push.Api/Contract/ResponseItem.cs
+++ b/Doppler.Push.Api/Contract/ResponseItem.cs
@@ -6,5 +6,6 @@ namespace Doppler.Push.Api.Contract
         public bool IsSuccess { get; set; }
         public ExceptionItem Exception { get; set; }
         public string DeviceToken { get; set; }
+        public SubscriptionDTO Subscription { get; set; }
     }
 }

--- a/Doppler.Push.Api/Controllers/MessageController.cs
+++ b/Doppler.Push.Api/Controllers/MessageController.cs
@@ -54,7 +54,7 @@ namespace Doppler.Push.Api.Controllers
                 Subscriptions = MapSubscriptions(pushNotificationRequest.Subscriptions),
             };
 
-            var response = await _dopplerMessageService.SendMulticastAsBatches(dto);
+            var response = await _dopplerMessageService.SendMulticast(dto);
 
             return Ok(response);
         }

--- a/Doppler.Push.Api/Controllers/MessageController.cs
+++ b/Doppler.Push.Api/Controllers/MessageController.cs
@@ -55,6 +55,7 @@ namespace Doppler.Push.Api.Controllers
                 NotificationBody = pushNotificationRequest.NotificationBody,
                 NotificationOnClickLink = pushNotificationRequest.NotificationOnClickLink,
                 ImageUrl = pushNotificationRequest.ImageUrl,
+                IconUrl = pushNotificationRequest.IconUrl,
                 Subscriptions = MapSubscriptions(pushNotificationRequest.Subscriptions),
                 MessageId = pushNotificationRequest.MessageId,
             };

--- a/Doppler.Push.Api/Controllers/MessageController.cs
+++ b/Doppler.Push.Api/Controllers/MessageController.cs
@@ -3,8 +3,6 @@ using Doppler.Push.Api.DopplerSecurity;
 using Doppler.Push.Api.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.DependencyInjection;
-using System;
 using System.Linq;
 using System.Threading.Tasks;
 

--- a/Doppler.Push.Api/Controllers/MessageController.cs
+++ b/Doppler.Push.Api/Controllers/MessageController.cs
@@ -44,7 +44,11 @@ namespace Doppler.Push.Api.Controllers
         [Route("/webpush")]
         public async Task<IActionResult> SendWebPush(PushNotificationRequest pushNotificationRequest)
         {
-            // TODO: reply 400 when "Suscriptions" field is missing
+            if (pushNotificationRequest.Subscriptions == null || pushNotificationRequest.Subscriptions.Length == 0)
+            {
+                return BadRequest("Subscriptions can not be empty.");
+            }
+
             var dto = new PushNotificationDTO()
             {
                 NotificationTitle = pushNotificationRequest.NotificationTitle,

--- a/Doppler.Push.Api/Controllers/MessageController.cs
+++ b/Doppler.Push.Api/Controllers/MessageController.cs
@@ -56,6 +56,7 @@ namespace Doppler.Push.Api.Controllers
                 NotificationOnClickLink = pushNotificationRequest.NotificationOnClickLink,
                 ImageUrl = pushNotificationRequest.ImageUrl,
                 Subscriptions = MapSubscriptions(pushNotificationRequest.Subscriptions),
+                MessageId = pushNotificationRequest.MessageId,
             };
 
             var response = await _dopplerMessageService.SendMulticast(dto);

--- a/Doppler.Push.Api/Services/DopplerMessageService.cs
+++ b/Doppler.Push.Api/Services/DopplerMessageService.cs
@@ -33,7 +33,7 @@ namespace Doppler.Push.Api.Services
                 // TODO: receive proper data and replace
                 Data = new NotificationData()
                 {
-                    MessageId = "test-api-3333",
+                    MessageId = request.MessageId,
                 },
             };
 

--- a/Doppler.Push.Api/Services/DopplerMessageService.cs
+++ b/Doppler.Push.Api/Services/DopplerMessageService.cs
@@ -76,7 +76,8 @@ namespace Doppler.Push.Api.Services
                         IsSuccess = false,
                         Exception = new ExceptionItem()
                         {
-                            Message = ex.Message,
+                            // TODO: set Message = ex.Message, and add logging for the current error
+                            Message = ex.StackTrace != null ? ex.StackTrace : ex.Message,
                             MessagingErrorCode = (int)HttpStatusCode.InternalServerError,
                         },
                         Subscription = subscription,

--- a/Doppler.Push.Api/Services/DopplerMessageService.cs
+++ b/Doppler.Push.Api/Services/DopplerMessageService.cs
@@ -63,7 +63,8 @@ namespace Doppler.Push.Api.Services
                         {
                             Message = ex.Message,
                             MessagingErrorCode = (int)HttpStatusCode.BadRequest,
-                        }
+                        },
+                        Subscription = subscription,
                     });
                     allFailureCount += 1;
                 }
@@ -76,7 +77,8 @@ namespace Doppler.Push.Api.Services
                         {
                             Message = ex.Message,
                             MessagingErrorCode = (int)HttpStatusCode.InternalServerError,
-                        }
+                        },
+                        Subscription = subscription,
                     });
                     allFailureCount += 1;
                 }

--- a/Doppler.Push.Api/Services/DopplerMessageService.cs
+++ b/Doppler.Push.Api/Services/DopplerMessageService.cs
@@ -1,4 +1,5 @@
 using Doppler.Push.Api.Contract;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -6,14 +7,51 @@ namespace Doppler.Push.Api.Services
 {
     public class DopplerMessageService : IMessageService
     {
+        private IWebPushClient _webPushClient;
+
         public DopplerMessageService()
         {
+            // TODO: obtains these values from config
+            var subject = "https://prueba.com";
+            var publicKey = "REPLACE_WITH_PUBLIC_KEY";
+            var privateKey = "REPLACE_WITH_PRIVATE_KEY";
+
+            _webPushClient = new WebPushClient();
+            _webPushClient.SetVapidDetails(subject, publicKey, privateKey);
         }
 
         public async Task<MessageSendResponse> SendMulticast(PushNotificationDTO request)
         {
-            await Task.Yield(); // it allows us to consider an async method without doing an operation
-            throw new Exception("Not implemented");
+            var payload = new NotificationPayload
+            {
+                Title = request.NotificationTitle,
+                Body = request.NotificationBody,
+                // TODO: replace properly
+                Icon = "https://png.pngtree.com/element_origin_min_pic/16/08/05/1057a3fae73b91b.jpg",
+                // TODO: receive proper data and replace
+                Data = new NotificationData()
+                {
+                    MessageId = "test-api-3333",
+                },
+            };
+
+            // Serializar el objeto a JSON
+            string serializedPayload = JsonConvert.SerializeObject(payload);
+
+            foreach (var subscription in request.Subscriptions)
+            {
+                await _webPushClient.SendNotificationAsync(subscription, serializedPayload);
+
+                //allResponses.AddRange(response.Responses);
+                //allFailureCount += response.FailureCount;
+                //allSuccessCount += response.SuccessCount;
+            }
+
+            return new MessageSendResponse()
+            {
+                SuccessCount = 0,
+                FailureCount = 0,
+            };
         }
 
         public async Task<MessageSendResponse> SendMulticastAsBatches(PushNotificationDTO request)

--- a/Doppler.Push.Api/Services/DopplerMessageService.cs
+++ b/Doppler.Push.Api/Services/DopplerMessageService.cs
@@ -24,22 +24,7 @@ namespace Doppler.Push.Api.Services
 
         public async Task<MessageSendResponse> SendMulticast(PushNotificationDTO request)
         {
-            var payload = new NotificationPayload
-            {
-                Title = request.NotificationTitle,
-                Body = request.NotificationBody,
-                // TODO: validate correct image and icon urls (https, etc)
-                Image = request.ImageUrl,
-                Icon = request.IconUrl,
-                Data = new NotificationData()
-                {
-                    MessageId = request.MessageId,
-                    ClickLink = request.NotificationOnClickLink,
-                },
-            };
-
-            // Serializar el objeto a JSON
-            string serializedPayload = JsonConvert.SerializeObject(payload);
+            var serializedPayload = SerializePayload(request);
 
             var allResponses = new List<ResponseItem>();
             var allFailureCount = 0;
@@ -104,6 +89,25 @@ namespace Doppler.Push.Api.Services
         {
             await Task.Yield(); // it allows us to consider an async method without doing an operation
             throw new Exception("Not implemented");
+        }
+
+        private string SerializePayload(PushNotificationDTO pushNotificationDTO)
+        {
+            var payload = new NotificationPayload
+            {
+                Title = pushNotificationDTO.NotificationTitle,
+                Body = pushNotificationDTO.NotificationBody,
+                // TODO: validate correct image and icon urls (https, etc)
+                Image = pushNotificationDTO.ImageUrl,
+                Icon = pushNotificationDTO.IconUrl,
+                Data = new NotificationData()
+                {
+                    MessageId = pushNotificationDTO.MessageId,
+                    ClickLink = pushNotificationDTO.NotificationOnClickLink,
+                },
+            };
+
+            return JsonConvert.SerializeObject(payload);
         }
     }
 }

--- a/Doppler.Push.Api/Services/DopplerMessageService.cs
+++ b/Doppler.Push.Api/Services/DopplerMessageService.cs
@@ -28,12 +28,13 @@ namespace Doppler.Push.Api.Services
             {
                 Title = request.NotificationTitle,
                 Body = request.NotificationBody,
-                // TODO: replace properly
-                Icon = "https://png.pngtree.com/element_origin_min_pic/16/08/05/1057a3fae73b91b.jpg",
-                // TODO: receive proper data and replace
+                // TODO: validate correct image and icon urls (https, etc)
+                Image = request.ImageUrl,
+                Icon = request.IconUrl,
                 Data = new NotificationData()
                 {
                     MessageId = request.MessageId,
+                    ClickLink = request.NotificationOnClickLink,
                 },
             };
 

--- a/Doppler.Push.Api/Services/DopplerMessageService.cs
+++ b/Doppler.Push.Api/Services/DopplerMessageService.cs
@@ -1,4 +1,5 @@
 using Doppler.Push.Api.Contract;
+using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -9,17 +10,16 @@ namespace Doppler.Push.Api.Services
 {
     public class DopplerMessageService : IMessageService
     {
-        private IWebPushClient _webPushClient;
+        private readonly IOptions<WebPushSettings> _webPushSettings;
+        private readonly IWebPushClient _webPushClient;
 
-        public DopplerMessageService()
+        public DopplerMessageService(IOptions<WebPushSettings> webPushSettings, IWebPushClient webPushClient)
         {
-            // TODO: obtains these values from config
-            var subject = "https://prueba.com";
-            var publicKey = "REPLACE_WITH_PUBLIC_KEY";
-            var privateKey = "REPLACE_WITH_PRIVATE_KEY";
+            _webPushSettings = webPushSettings;
+            _webPushClient = webPushClient;
 
-            _webPushClient = new WebPushClient();
-            _webPushClient.SetVapidDetails(subject, publicKey, privateKey);
+            var settings = _webPushSettings.Value;
+            _webPushClient.SetVapidDetails(settings.Subject, settings.PublicKey, settings.PrivateKey);
         }
 
         public async Task<MessageSendResponse> SendMulticast(PushNotificationDTO request)

--- a/Doppler.Push.Api/Services/IWebPushClient.cs
+++ b/Doppler.Push.Api/Services/IWebPushClient.cs
@@ -30,7 +30,6 @@ namespace Doppler.Push.Api.Services
         ///     notification.
         /// </param>
         /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
-        Task SendNotificationAsync(SubscriptionDTO subscription, string payload = null, Dictionary<string, object> options = null, CancellationToken cancellationToken = default);
         Task<ResponseItem> SendNotificationAsync(SubscriptionDTO subscription, string payload = null, Dictionary<string, object> options = null, CancellationToken cancellationToken = default);
     }
 }

--- a/Doppler.Push.Api/Services/IWebPushClient.cs
+++ b/Doppler.Push.Api/Services/IWebPushClient.cs
@@ -31,5 +31,6 @@ namespace Doppler.Push.Api.Services
         /// </param>
         /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         Task SendNotificationAsync(SubscriptionDTO subscription, string payload = null, Dictionary<string, object> options = null, CancellationToken cancellationToken = default);
+        Task<ResponseItem> SendNotificationAsync(SubscriptionDTO subscription, string payload = null, Dictionary<string, object> options = null, CancellationToken cancellationToken = default);
     }
 }

--- a/Doppler.Push.Api/Services/WebPushClient.cs
+++ b/Doppler.Push.Api/Services/WebPushClient.cs
@@ -237,8 +237,7 @@ namespace Doppler.Push.Api.Services
             {
                 if (ex is FormatException || ex is ArgumentException)
                 {
-                    // TODO: treat exception properly
-                    //throw new InvalidEncryptionDetailsException("Unable to encrypt the payload with the encryption key of this subscription.", subscription);
+                    throw new ArgumentException("Unable to encrypt the payload with the encryption key of this subscription.");
                 }
 
                 throw;
@@ -258,8 +257,7 @@ namespace Doppler.Push.Api.Services
                 return new ResponseItem()
                 {
                     IsSuccess = true,
-                    // TODO: associate suscription info associated to the current response
-                    // Suscription =
+                    Subscription = subscription,
                 };
             }
 
@@ -303,8 +301,7 @@ namespace Doppler.Push.Api.Services
                     Message = message,
                     MessagingErrorCode = (int)response.StatusCode,
                 },
-                // TODO: associate suscription info associated to the current response
-                // Suscription =
+                Subscription = subscription,
             };
         }
 

--- a/Doppler.Push.Api/Services/WebPushClient.cs
+++ b/Doppler.Push.Api/Services/WebPushClient.cs
@@ -139,7 +139,7 @@ namespace Doppler.Push.Api.Services
                 {
                     if (!validOptionsKeys.Contains(key))
                     {
-                        throw new ArgumentException(key + " is an invalid options. The valid options are" + string.Join(",", validOptionsKeys));
+                        throw new ArgumentException($"{key} is an invalid option. The valid options are {string.Join(",", validOptionsKeys)}");
                     }
                 }
 

--- a/Doppler.Push.Api/Services/WebPushClient.cs
+++ b/Doppler.Push.Api/Services/WebPushClient.cs
@@ -179,12 +179,6 @@ namespace Doppler.Push.Api.Services
 
             if (!string.IsNullOrEmpty(payload))
             {
-                if (string.IsNullOrEmpty(subscription.P256DH) || string.IsNullOrEmpty(subscription.Auth))
-                {
-                    throw new ArgumentException(
-                        @"Unable to send a message with payload to this subscription since it doesn't have the required encryption key");
-                }
-
                 var encryptedPayload = EncryptPayload(subscription, payload);
 
                 request.Content = new ByteArrayContent(encryptedPayload.Payload);

--- a/Doppler.Push.Api/Services/WebPushSettings.cs
+++ b/Doppler.Push.Api/Services/WebPushSettings.cs
@@ -1,0 +1,9 @@
+namespace Doppler.Push.Api.Services
+{
+    public class WebPushSettings
+    {
+        public string Subject { get; set; }
+        public string PublicKey { get; set; }
+        public string PrivateKey { get; set; }
+    }
+}

--- a/Doppler.Push.Api/Startup.cs
+++ b/Doppler.Push.Api/Startup.cs
@@ -60,6 +60,10 @@ namespace Doppler.Push.Api
             services.AddSingleton<FirebaseCloudMessageService>();
             services.AddSingleton<DopplerMessageService>();
             services.AddSingleton<IMessageServiceFactory, MessageServiceFactory>();
+
+            var webPushSettings = Configuration.GetSection("WebPushSettings").Get<WebPushSettings>();
+            services.AddSingleton<IWebPushClient>(new WebPushClient());
+            services.Configure<WebPushSettings>(Configuration.GetSection("WebPushSettings"));
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/Doppler.Push.Api/appsettings.json
+++ b/Doppler.Push.Api/appsettings.json
@@ -32,7 +32,7 @@
     "BatchesSize": 1000
   },
   "WebPushSettings": {
-    "Subject": "https://apisint.fromdoppler.net/",
+    "Subject": "https://apisint.fromdoppler.net",
     "PublicKey": "REPLACE_WITH_PUBLIC_KEY",
     "PrivateKey": "REPLACE_WITH_PRIVATE_KEY"
   }

--- a/Doppler.Push.Api/appsettings.json
+++ b/Doppler.Push.Api/appsettings.json
@@ -30,5 +30,10 @@
   },
   "FirebaseCloudMessageServiceSettings": {
     "BatchesSize": 1000
+  },
+  "WebPushSettings": {
+    "Subject": "https://apisint.fromdoppler.net/",
+    "PublicKey": "REPLACE_WITH_PUBLIC_KEY",
+    "PrivateKey": "REPLACE_WITH_PRIVATE_KEY"
   }
 }


### PR DESCRIPTION
- Se agrega el comportamiento en DopplerMessageService para que envie notificaciones utilizando el cliente WebPush:
![chrome_5NbpkTppZx](https://github.com/FromDoppler/doppler-push-api/assets/1985175/37ebf25a-ac8f-4f48-9316-84ab4e8b9ead)
- Ademas de las propiedades ya utilizadas con firebase (title, body, image, y clickLink), se agregó el `icon` (**TODO**: analizar comportamiento en distintos dispositivos):
![image](https://github.com/FromDoppler/doppler-push-api/assets/1985175/5ca94df5-3381-4ee6-a7cb-81ef3d3a33eb)

**TODO:** 
- los `WebPushSettings` deben guardarse con los secretos de swarm (será considerado en este PR)
- agregar tests, prioritariamente, a MessageController y DopplerMessageService. Tambien podrian agregarse a las clases asociadas a WebPushClient.
- probar performance, y analizar optimizaciones de envio (https://makingsense.atlassian.net/browse/DOP-1555)
