### PR TITLE
Dop 1570 improve behavior treating errors on sending

### DIFF
--- a/Doppler.Push.Api.Test/Services/DopplerMessageServiceTest.cs
+++ b/Doppler.Push.Api.Test/Services/DopplerMessageServiceTest.cs
@@ -1,5 +1,6 @@
 using AutoFixture;
 using Doppler.Push.Api.Contract;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
 using System;
@@ -13,11 +14,16 @@ namespace Doppler.Push.Api.Services
 {
     public class DopplerMessageServiceTest
     {
-        private static DopplerMessageService CreateSut(IOptions<WebPushSettings> webPushSettings = null, IWebPushClient webPushClient = null)
+        private static DopplerMessageService CreateSut(
+            IOptions<WebPushSettings> webPushSettings = null,
+            IWebPushClient webPushClient = null,
+            ILogger<DopplerMessageService> logger = null
+        )
         {
             return new DopplerMessageService(
                 webPushSettings ?? Mock.Of<IOptions<WebPushSettings>>(),
-                webPushClient ?? Mock.Of<IWebPushClient>()
+                webPushClient ?? Mock.Of<IWebPushClient>(),
+                logger ?? Mock.Of<ILogger<DopplerMessageService>>()
             );
         }
 

--- a/Doppler.Push.Api/Contract/ExceptionItem.cs
+++ b/Doppler.Push.Api/Contract/ExceptionItem.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Doppler.Push.Api.Contract
 {
     public class ExceptionItem
@@ -27,5 +29,6 @@ namespace Doppler.Push.Api.Contract
 
         public int MessagingErrorCode { get; set; }
         public string Message { get; set; }
+        public TimeSpan? RetryAfterSeconds { get; set; }
     }
 }

--- a/Doppler.Push.Api/Services/WebPushClient.cs
+++ b/Doppler.Push.Api/Services/WebPushClient.cs
@@ -294,6 +294,7 @@ namespace Doppler.Push.Api.Services
                 {
                     Message = message,
                     MessagingErrorCode = (int)response.StatusCode,
+                    RetryAfterSeconds = response.Headers.RetryAfter != null ? response.Headers.RetryAfter.Delta : null,
                 },
                 Subscription = subscription,
             };

--- a/Doppler.Push.Api/Startup.cs
+++ b/Doppler.Push.Api/Startup.cs
@@ -62,7 +62,7 @@ namespace Doppler.Push.Api
             services.AddSingleton<IMessageServiceFactory, MessageServiceFactory>();
 
             var webPushSettings = Configuration.GetSection("WebPushSettings").Get<WebPushSettings>();
-            services.AddSingleton<IWebPushClient>(new WebPushClient());
+            services.AddSingleton<IWebPushClient, WebPushClient>();
             services.Configure<WebPushSettings>(Configuration.GetSection("WebPushSettings"));
         }
 


### PR DESCRIPTION
- add logging and return useful information when identifying a WebPush response with `HttpStatusCode 429`.
- add logging when happened an unexpected error and "fix" the message in response.